### PR TITLE
Use more generic API for adding to BQMs

### DIFF
--- a/car_paint_shop.py
+++ b/car_paint_shop.py
@@ -114,7 +114,7 @@ def get_paint_shop_bqm(cqm: dimod.ConstrainedQuadraticModel, penalty=2.0):
     bqm.add_linear_from(cqm.objective.linear)
     bqm.add_quadratic_from(cqm.objective.quadratic)
     for c in cqm.constraints.values():
-        bqm.update(penalty * (c.lhs - c.rhs) ** 2)
+        bqm += penalty * (c.lhs - c.rhs) ** 2
     return bqm
 
 


### PR DESCRIPTION
CQM constraints can be BQMs or QMs in Ocean 5.x, or expressions in Ocean 6.x. The new syntax is generic to all options rather than assuming them to be a BQM as before.